### PR TITLE
ENH: Add flush option.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # List required packages in this file, one per line.
-event-model >=1.8.0rc1
+event-model >=1.8.0
 pandas
 suitcase-utils 


### PR DESCRIPTION
Closes #14 

Demo GIF shows a `Serializer` with `flush=True` subscribe to `RE`. In a second tab, I am tailing the CSV file while the plan is being executed. Each line appears as the corresponding doucment is emitted by the RunEngine.

![demo](https://user-images.githubusercontent.com/2279598/58373180-0907b500-7ef8-11e9-8acf-750b1be4adfb.gif)

If `flush=False` (the default) it is left up to Python when to flush the file to disk, and it typically does so at the end of the run all at once.

attn @EliotGann